### PR TITLE
fix: Correct SAML auth URL parsing to fix connection failure (#7)

### DIFF
--- a/src/services/vpnService.ts
+++ b/src/services/vpnService.ts
@@ -384,7 +384,88 @@ export class VpnService {
         this._pendingCertHash = null;
         this._awaitingCertTrust = false;
     }
-    
+
+    /**
+     * Extract the SAML authentication URL from a single line of openfortivpn
+     * output. Returns null when the line does not contain an auth URL.
+     *
+     * openfortivpn prints the URL wrapped in quotes, e.g.
+     *   Authenticate at 'https://gw.example.com/remote/saml/start?redirect=1'
+     * The previous implementation matched everything up to the next whitespace,
+     * which captured the trailing quote (".../redirect=1'"). That broke the
+     * `redirect` query parameter, so the gateway ignored it and served its web
+     * portal page ("tunnel mode use only / FortiClient required") instead of
+     * starting the SAML flow (issue #7).
+     *
+     * @param text Output to scan (a single line, or the residual buffer).
+     * @param requireTerminator When true, only a quote-terminated URL is
+     *   accepted. The closing quote proves the URL was received in full, which
+     *   lets us safely parse an un-terminated residual buffer without risking a
+     *   truncated URL.
+     */
+    private extractSamlAuthUrl(text: string, requireTerminator: boolean): string | null {
+        // Only consider output that looks like an auth prompt to avoid opening
+        // unrelated URLs that may appear in logs.
+        if (!/authenticate|saml|\/remote\/|please|login/i.test(text)) {
+            return null;
+        }
+
+        // Preferred form: openfortivpn wraps the URL in quotes. The closing
+        // quote guarantees the URL is complete even without a trailing newline.
+        const quoted = text.match(/['"]\s*(https?:\/\/[^'"\s]+)\s*['"]/i);
+        if (quoted && quoted[1]) {
+            return quoted[1];
+        }
+
+        // Without a closing quote we cannot tell a complete URL from one that is
+        // still streaming in, so a partial buffer must wait for more data.
+        if (requireTerminator) {
+            return null;
+        }
+
+        const match = text.match(/https?:\/\/[^\s]+/i);
+        if (!match) {
+            return null;
+        }
+
+        let url = match[0];
+        // Strip wrapping/trailing punctuation that openfortivpn (or a log
+        // formatter) may place around the URL: quotes, brackets, angle
+        // brackets, and sentence punctuation.
+        url = url.replace(/^['"<(\[]+/, '');
+        url = url.replace(/['"'`.,;>)\]]+$/, '');
+
+        return url.length > 0 ? url : null;
+    }
+
+    /**
+     * Open the SAML authentication URL in the browser and guide the user. The
+     * URL is opened in the system default browser; when the user already has an
+     * identity-provider session there (e.g. Microsoft), the gateway flow can
+     * fail, so we also surface the URL with copy/incognito guidance (issue #7).
+     */
+    private async handleSamlAuthentication(authUrl: string): Promise<void> {
+        this._logger.log(`Opening SAML authentication URL in browser: ${authUrl}`, true);
+        await vscode.env.openExternal(vscode.Uri.parse(authUrl));
+
+        const copyAction = 'Copy URL';
+        const openAction = 'Open Again';
+        const choice = await vscode.window.showInformationMessage(
+            'SAML sign-in opened in your browser. If authentication fails because ' +
+            'you are already signed in (e.g. Microsoft), copy the URL and open it ' +
+            'in a private/incognito window instead.',
+            copyAction,
+            openAction
+        );
+
+        if (choice === copyAction) {
+            await vscode.env.clipboard.writeText(authUrl);
+            vscode.window.showInformationMessage('SAML authentication URL copied to clipboard.');
+        } else if (choice === openAction) {
+            await vscode.env.openExternal(vscode.Uri.parse(authUrl));
+        }
+    }
+
     /**
      * Connect to VPN using the specified profile
      * @param profile VPN profile to connect with
@@ -523,6 +604,13 @@ export class VpnService {
             
             // Track if we've sent the VPN password
             let vpnPasswordSent = false;
+
+            // SAML auth state: ensure the browser is opened exactly once with a
+            // complete URL. stdout arrives in arbitrary chunks, so we buffer it
+            // and only parse fully terminated lines to avoid acting on a
+            // truncated URL.
+            let samlAuthOpened = false;
+            let samlStdoutBuffer = '';
             
             // Pass sudo password to stdin immediately (sudo -S reads from stdin right away)
             if (this._currentProcess.stdin && sudoPassword) {
@@ -584,14 +672,48 @@ export class VpnService {
                         }
                     }
                     
-                    // Check for SAML authentication URL and auto-open browser
-                    if (useSaml) {
-                        // Look for SAML login URL patterns
-                        const urlMatch = output.match(/(https?:\/\/[^\s]+)/i);
-                        if (urlMatch && urlMatch[1] && (output.includes('authenticate') || output.includes('login') || output.includes('saml') || output.includes('Please'))) {
-                            const authUrl = urlMatch[1];
-                            this._logger.log(`Opening SAML authentication URL in browser: ${authUrl}`, true);
-                            vscode.env.openExternal(vscode.Uri.parse(authUrl));
+                    // Check for SAML authentication URL and open the browser.
+                    // openfortivpn prints the URL wrapped in quotes (e.g.
+                    // Authenticate at 'https://.../remote/saml/start?redirect=1').
+                    // We must extract it exactly: keeping a trailing quote breaks
+                    // the `redirect` parameter and the gateway falls back to its
+                    // web portal page instead of starting the SAML flow.
+                    if (useSaml && !samlAuthOpened) {
+                        samlStdoutBuffer += output;
+
+                        const openSamlAuth = (authUrl: string) => {
+                            samlAuthOpened = true;
+                            this.handleSamlAuthentication(authUrl).catch(err =>
+                                this._logger.log(`SAML authentication handling failed: ${err}`, true));
+                        };
+
+                        // Primary path: parse fully terminated lines so we never
+                        // act on a URL that was split across stdout chunks.
+                        let newlineIndex: number;
+                        while (!samlAuthOpened && (newlineIndex = samlStdoutBuffer.indexOf('\n')) >= 0) {
+                            const line = samlStdoutBuffer.slice(0, newlineIndex);
+                            samlStdoutBuffer = samlStdoutBuffer.slice(newlineIndex + 1);
+
+                            const authUrl = this.extractSamlAuthUrl(line, false);
+                            if (authUrl) {
+                                openSamlAuth(authUrl);
+                            }
+                        }
+
+                        // Fallback: openfortivpn may print the prompt and then
+                        // block on the SAML callback without a trailing newline.
+                        // A quote-terminated URL in the residual buffer is known
+                        // to be complete, so open it without waiting for '\n'.
+                        if (!samlAuthOpened) {
+                            const authUrl = this.extractSamlAuthUrl(samlStdoutBuffer, true);
+                            if (authUrl) {
+                                openSamlAuth(authUrl);
+                            }
+                        }
+
+                        // Guard against unbounded growth if no newline ever comes.
+                        if (samlStdoutBuffer.length > 8192) {
+                            samlStdoutBuffer = samlStdoutBuffer.slice(-4096);
                         }
                     }
                     

--- a/src/services/vpnService.ts
+++ b/src/services/vpnService.ts
@@ -446,23 +446,36 @@ export class VpnService {
      */
     private async handleSamlAuthentication(authUrl: string): Promise<void> {
         this._logger.log(`Opening SAML authentication URL in browser: ${authUrl}`, true);
-        await vscode.env.openExternal(vscode.Uri.parse(authUrl));
+
+        let opened = false;
+        try {
+            opened = await vscode.env.openExternal(vscode.Uri.parse(authUrl));
+        } catch (err) {
+            this._logger.error('Failed to open SAML authentication URL automatically', err, false);
+        }
 
         const copyAction = 'Copy URL';
         const openAction = 'Open Again';
-        const choice = await vscode.window.showInformationMessage(
-            'SAML sign-in opened in your browser. If authentication fails because ' +
-            'you are already signed in (e.g. Microsoft), copy the URL and open it ' +
-            'in a private/incognito window instead.',
-            copyAction,
-            openAction
-        );
+        // Always surface the URL so the user can fall back to copying it,
+        // especially when the automatic open failed or an existing identity
+        // provider session in the default browser breaks the flow.
+        const message = opened
+            ? 'SAML sign-in opened in your browser. If authentication fails because ' +
+              'you are already signed in (e.g. Microsoft), copy the URL and open it ' +
+              'in a private/incognito window instead.'
+            : 'Could not open SAML sign-in automatically. Copy the URL and open it ' +
+              'in your browser manually.';
+        const choice = await vscode.window.showInformationMessage(message, copyAction, openAction);
 
         if (choice === copyAction) {
             await vscode.env.clipboard.writeText(authUrl);
             vscode.window.showInformationMessage('SAML authentication URL copied to clipboard.');
         } else if (choice === openAction) {
-            await vscode.env.openExternal(vscode.Uri.parse(authUrl));
+            try {
+                await vscode.env.openExternal(vscode.Uri.parse(authUrl));
+            } catch (err) {
+                this._logger.error('Failed to open SAML authentication URL', err);
+            }
         }
     }
 
@@ -684,7 +697,7 @@ export class VpnService {
                         const openSamlAuth = (authUrl: string) => {
                             samlAuthOpened = true;
                             this.handleSamlAuthentication(authUrl).catch(err =>
-                                this._logger.log(`SAML authentication handling failed: ${err}`, true));
+                                this._logger.error('SAML authentication handling failed', err));
                         };
 
                         // Primary path: parse fully terminated lines so we never

--- a/src/services/vpnService.ts
+++ b/src/services/vpnService.ts
@@ -4,6 +4,7 @@ import { VpnProfile } from '../models/profile';
 import { ProfileManager } from '../models/profileManager';
 import { LogService } from './logService';
 import { MetricsService } from './metricsService';
+import { scanSamlAuthOutput } from '../utils/samlAuth';
 
 /**
  * Password key for SecretStorage
@@ -386,59 +387,6 @@ export class VpnService {
     }
 
     /**
-     * Extract the SAML authentication URL from a single line of openfortivpn
-     * output. Returns null when the line does not contain an auth URL.
-     *
-     * openfortivpn prints the URL wrapped in quotes, e.g.
-     *   Authenticate at 'https://gw.example.com/remote/saml/start?redirect=1'
-     * The previous implementation matched everything up to the next whitespace,
-     * which captured the trailing quote (".../redirect=1'"). That broke the
-     * `redirect` query parameter, so the gateway ignored it and served its web
-     * portal page ("tunnel mode use only / FortiClient required") instead of
-     * starting the SAML flow (issue #7).
-     *
-     * @param text Output to scan (a single line, or the residual buffer).
-     * @param requireTerminator When true, only a quote-terminated URL is
-     *   accepted. The closing quote proves the URL was received in full, which
-     *   lets us safely parse an un-terminated residual buffer without risking a
-     *   truncated URL.
-     */
-    private extractSamlAuthUrl(text: string, requireTerminator: boolean): string | null {
-        // Only consider output that looks like an auth prompt to avoid opening
-        // unrelated URLs that may appear in logs.
-        if (!/authenticate|saml|\/remote\/|please|login/i.test(text)) {
-            return null;
-        }
-
-        // Preferred form: openfortivpn wraps the URL in quotes. The closing
-        // quote guarantees the URL is complete even without a trailing newline.
-        const quoted = text.match(/['"]\s*(https?:\/\/[^'"\s]+)\s*['"]/i);
-        if (quoted && quoted[1]) {
-            return quoted[1];
-        }
-
-        // Without a closing quote we cannot tell a complete URL from one that is
-        // still streaming in, so a partial buffer must wait for more data.
-        if (requireTerminator) {
-            return null;
-        }
-
-        const match = text.match(/https?:\/\/[^\s]+/i);
-        if (!match) {
-            return null;
-        }
-
-        let url = match[0];
-        // Strip wrapping/trailing punctuation that openfortivpn (or a log
-        // formatter) may place around the URL: quotes, brackets, angle
-        // brackets, and sentence punctuation.
-        url = url.replace(/^['"<(\[]+/, '');
-        url = url.replace(/['"'`.,;>)\]]+$/, '');
-
-        return url.length > 0 ? url : null;
-    }
-
-    /**
      * Open the SAML authentication URL in the browser and guide the user. The
      * URL is opened in the system default browser; when the user already has an
      * identity-provider session there (e.g. Microsoft), the gateway flow can
@@ -692,41 +640,12 @@ export class VpnService {
                     // the `redirect` parameter and the gateway falls back to its
                     // web portal page instead of starting the SAML flow.
                     if (useSaml && !samlAuthOpened) {
-                        samlStdoutBuffer += output;
-
-                        const openSamlAuth = (authUrl: string) => {
+                        const scan = scanSamlAuthOutput(samlStdoutBuffer, output);
+                        samlStdoutBuffer = scan.buffer;
+                        if (scan.url) {
                             samlAuthOpened = true;
-                            this.handleSamlAuthentication(authUrl).catch(err =>
+                            this.handleSamlAuthentication(scan.url).catch(err =>
                                 this._logger.error('SAML authentication handling failed', err));
-                        };
-
-                        // Primary path: parse fully terminated lines so we never
-                        // act on a URL that was split across stdout chunks.
-                        let newlineIndex: number;
-                        while (!samlAuthOpened && (newlineIndex = samlStdoutBuffer.indexOf('\n')) >= 0) {
-                            const line = samlStdoutBuffer.slice(0, newlineIndex);
-                            samlStdoutBuffer = samlStdoutBuffer.slice(newlineIndex + 1);
-
-                            const authUrl = this.extractSamlAuthUrl(line, false);
-                            if (authUrl) {
-                                openSamlAuth(authUrl);
-                            }
-                        }
-
-                        // Fallback: openfortivpn may print the prompt and then
-                        // block on the SAML callback without a trailing newline.
-                        // A quote-terminated URL in the residual buffer is known
-                        // to be complete, so open it without waiting for '\n'.
-                        if (!samlAuthOpened) {
-                            const authUrl = this.extractSamlAuthUrl(samlStdoutBuffer, true);
-                            if (authUrl) {
-                                openSamlAuth(authUrl);
-                            }
-                        }
-
-                        // Guard against unbounded growth if no newline ever comes.
-                        if (samlStdoutBuffer.length > 8192) {
-                            samlStdoutBuffer = samlStdoutBuffer.slice(-4096);
                         }
                     }
                     

--- a/src/test/samlAuth.test.ts
+++ b/src/test/samlAuth.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+import { extractSamlAuthUrl, scanSamlAuthOutput } from '../utils/samlAuth';
+
+const URL = 'https://gw.example.com/remote/saml/start?redirect=1';
+
+suite('extractSamlAuthUrl', () => {
+    test('strips the wrapping single quotes openfortivpn prints (issue #7)', () => {
+        const line = `Authenticate at '${URL}'`;
+        assert.strictEqual(extractSamlAuthUrl(line, false), URL);
+    });
+
+    test('preserves the redirect query parameter intact', () => {
+        const line = `Authenticate at '${URL}'`;
+        const result = extractSamlAuthUrl(line, false);
+        assert.ok(result && result.endsWith('redirect=1'), 'redirect param must survive');
+        assert.ok(result && !result.includes("'"), 'no quote may leak into the URL');
+    });
+
+    test('handles double quotes', () => {
+        assert.strictEqual(extractSamlAuthUrl(`Please authenticate at "${URL}"`, false), URL);
+    });
+
+    test('handles an unquoted URL terminated by whitespace', () => {
+        assert.strictEqual(extractSamlAuthUrl(`Please authenticate at ${URL}`, false), URL);
+    });
+
+    test('strips trailing sentence punctuation from an unquoted URL', () => {
+        assert.strictEqual(extractSamlAuthUrl(`Authenticate at ${URL}.`, false), URL);
+    });
+
+    test('accepts a quote-terminated URL when a terminator is required', () => {
+        assert.strictEqual(extractSamlAuthUrl(`Authenticate at '${URL}'`, true), URL);
+    });
+
+    test('rejects an unquoted (possibly truncated) URL when a terminator is required', () => {
+        assert.strictEqual(extractSamlAuthUrl(`Authenticate at ${URL}`, true), null);
+    });
+
+    test('returns null for unrelated output', () => {
+        assert.strictEqual(extractSamlAuthUrl('Tunnel is up and running', false), null);
+        assert.strictEqual(extractSamlAuthUrl('VPN output: connecting...', false), null);
+    });
+});
+
+suite('scanSamlAuthOutput', () => {
+    test('finds the URL in a single newline-terminated chunk', () => {
+        const { url } = scanSamlAuthOutput('', `Authenticate at '${URL}'\n`);
+        assert.strictEqual(url, URL);
+    });
+
+    test('reassembles a URL split across stdout chunks', () => {
+        const full = `Authenticate at '${URL}'\n`;
+        const mid = Math.floor(full.length / 2);
+        let { url, buffer } = scanSamlAuthOutput('', full.slice(0, mid));
+        assert.strictEqual(url, null, 'must wait for the rest of the URL');
+        ({ url, buffer } = scanSamlAuthOutput(buffer, full.slice(mid)));
+        assert.strictEqual(url, URL);
+    });
+
+    test('opens a quote-terminated URL even without a trailing newline', () => {
+        const { url } = scanSamlAuthOutput('', `Authenticate at '${URL}'`);
+        assert.strictEqual(url, URL);
+    });
+
+    test('does not open a truncated, unterminated URL', () => {
+        const { url } = scanSamlAuthOutput('', 'Authenticate at https://gw.example.com/remote/sa');
+        assert.strictEqual(url, null);
+    });
+
+    test('finds the URL after unrelated leading lines', () => {
+        const chunk = 'Connecting...\nReading password\n' + `Authenticate at '${URL}'\n`;
+        const { url } = scanSamlAuthOutput('', chunk);
+        assert.strictEqual(url, URL);
+    });
+
+    test('trims an oversized buffer but still finds a later complete URL', () => {
+        let { buffer } = scanSamlAuthOutput('', 'x'.repeat(9000));
+        assert.ok(buffer.length <= 8192, 'buffer must be trimmed');
+        const { url } = scanSamlAuthOutput(buffer, `Authenticate at '${URL}'\n`);
+        assert.strictEqual(url, URL);
+    });
+});

--- a/src/utils/samlAuth.ts
+++ b/src/utils/samlAuth.ts
@@ -1,0 +1,109 @@
+/**
+ * Parsing helpers for extracting the SAML authentication URL from the stdout of
+ * `openfortivpn --saml-login`.
+ *
+ * These are pure, side-effect-free functions so the URL parsing — the part that
+ * regressed in issue #7 — can be unit tested without a VS Code host or a live
+ * gateway.
+ */
+
+/**
+ * Extract the SAML authentication URL from a piece of openfortivpn output.
+ * Returns null when no auth URL is present.
+ *
+ * openfortivpn prints the URL wrapped in quotes, e.g.
+ *   Authenticate at 'https://gw.example.com/remote/saml/start?redirect=1'
+ * A naive `https?://\S+` match captures the trailing quote (".../redirect=1'"),
+ * which corrupts the `redirect` query parameter. The gateway then ignores it and
+ * serves its web portal page ("tunnel mode use only / FortiClient required")
+ * instead of starting the SAML flow (issue #7).
+ *
+ * @param text Output to scan (a single line, or the residual buffer).
+ * @param requireTerminator When true, only a quote-terminated URL is accepted.
+ *   The closing quote proves the URL was received in full, which lets us safely
+ *   parse an un-terminated residual buffer without risking a truncated URL.
+ */
+export function extractSamlAuthUrl(text: string, requireTerminator: boolean): string | null {
+    // Only consider output that looks like an auth prompt to avoid opening
+    // unrelated URLs that may appear in logs.
+    if (!/authenticate|saml|\/remote\/|please|login/i.test(text)) {
+        return null;
+    }
+
+    // Preferred form: openfortivpn wraps the URL in quotes. The closing quote
+    // guarantees the URL is complete even without a trailing newline.
+    const quoted = text.match(/['"]\s*(https?:\/\/[^'"\s]+)\s*['"]/i);
+    if (quoted && quoted[1]) {
+        return quoted[1];
+    }
+
+    // Without a closing quote we cannot tell a complete URL from one that is
+    // still streaming in, so a partial buffer must wait for more data.
+    if (requireTerminator) {
+        return null;
+    }
+
+    const match = text.match(/https?:\/\/[^\s]+/i);
+    if (!match) {
+        return null;
+    }
+
+    let url = match[0];
+    // Strip wrapping/trailing punctuation that openfortivpn (or a log formatter)
+    // may place around the URL: quotes, brackets, angle brackets, and sentence
+    // punctuation.
+    url = url.replace(/^['"<(\[]+/, '');
+    url = url.replace(/['"'`.,;>)\]]+$/, '');
+
+    return url.length > 0 ? url : null;
+}
+
+/** Largest residual buffer we keep before trimming, in characters. */
+const MAX_BUFFER = 8192;
+/** Amount of the tail we retain when trimming an oversized buffer. */
+const BUFFER_TRIM_TAIL = 4096;
+
+export interface SamlScanResult {
+    /** The auth URL once a complete one is found, otherwise null. */
+    url: string | null;
+    /** The carry-over buffer to pass into the next call. */
+    buffer: string;
+}
+
+/**
+ * Feed the next stdout chunk into the SAML URL scanner.
+ *
+ * stdout arrives in arbitrary chunks, so a URL can be split across reads. We
+ * accumulate into `buffer` and parse only fully terminated lines, which means a
+ * split URL is never opened truncated. If the prompt arrives without a trailing
+ * newline (openfortivpn can print it and then block on the callback), we fall
+ * back to a quote-terminated URL in the residual buffer, which is known to be
+ * complete.
+ *
+ * @param buffer Carry-over buffer from the previous call ('' on first call).
+ * @param chunk  The newly received stdout chunk.
+ */
+export function scanSamlAuthOutput(buffer: string, chunk: string): SamlScanResult {
+    buffer += chunk;
+    let url: string | null = null;
+
+    // Primary path: consume fully terminated lines.
+    let newlineIndex: number;
+    while (url === null && (newlineIndex = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        url = extractSamlAuthUrl(line, false);
+    }
+
+    // Fallback: quote-terminated URL in the un-terminated residual buffer.
+    if (url === null) {
+        url = extractSamlAuthUrl(buffer, true);
+    }
+
+    // Guard against unbounded growth if no newline ever comes.
+    if (buffer.length > MAX_BUFFER) {
+        buffer = buffer.slice(-BUFFER_TRIM_TAIL);
+    }
+
+    return { url, buffer };
+}


### PR DESCRIPTION
## Summary

Fixes #7 — connecting via SAML SSO from the extension showed the FortiGate web portal page ("The SSL-VPN portal has been enabled for tunnel mode use only. FortiClient is required to connect.") instead of starting the SAML sign-in, even though the same `openfortivpn ... --saml-login` command worked from the terminal.

## Root cause

`openfortivpn` prints the SAML auth URL wrapped in single quotes:

```
Authenticate at 'https://gw/remote/saml/start?redirect=1'
```

The old extraction regex `/(https?:\/\/[^\s]+)/i` matched up to the next whitespace and **captured the trailing quote**, producing `...redirect=1'`. That corrupted the `redirect` query parameter, so the gateway ignored the SAML flow and fell back to its web portal page. The issue surfaced only in the extension (not the terminal) because the extension auto-opens the URL in the **default browser**, where an existing identity-provider session (e.g. Microsoft) made the broken fallback path visible — matching the reporter's "works in incognito" observation.

## Changes

- **Precise URL extraction** (`extractSamlAuthUrl`): prefer the quote-wrapped form and strip wrapping/trailing punctuation so `redirect` stays intact.
- **Chunk-safe parsing**: buffer stdout and parse only fully terminated lines, so a URL split across stdout chunks is never opened truncated. When the prompt arrives without a trailing newline, a quote-terminated URL in the residual buffer is treated as complete.
- **Open exactly once**: guard flag prevents multiple browser launches / session conflicts.
- **Better UX for existing sessions**: surfaces the URL with Copy URL / Open Again actions and guidance to use a private/incognito window when already signed in to the IdP.

## Verification

- `npm run compile` (tsc type-check + eslint + esbuild) passes clean.
- Extraction logic validated across cases: quoted URL (quote stripped, `redirect` preserved), unquoted URL, residual-buffer quote-terminated URL, mid-stream truncated URL (correctly ignored), and unrelated log lines.

## Note for the reporter

@mritunjaymusale this should make the extension behave like the terminal command. If your default browser keeps an active Microsoft session, you can also use the new "Copy URL" action and paste it into a private/incognito window.